### PR TITLE
Fix bug with RAM calculation

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -117,17 +117,14 @@ function getRamTotal()
             $result = $matches[1];
         }
     } else {
-        $fh = fopen('/proc/meminfo', 'r');
-        while ($line = fgets($fh)) {
-            $pieces = array();
-            if (preg_match('/^MemTotal:\s+(\d+)\skB$/', $line, $pieces)) {
-                $result = $pieces[1];
-                // KB to Bytes
-                $result = $result * 1024;
-                break;
+        $top = shell_exec('free -m');
+        $output = preg_split('/[\s]/', $top);
+            for ($i=count($output)-1; $i>=0; $i--) {
+            if ($output[$i] == '') unset ($output[$i]);
             }
-        }
-        fclose($fh);
+        $output = array_values($output);
+        $ramTotal = $output[7]/1000; // GB
+        $result = $ramTotal;
     }
     // KB RAM Total
     return (int) $result;
@@ -147,16 +144,14 @@ function getRamFree()
             $result = $matches[1] * 1024;
         }
     } else {
-        $fh = fopen('/proc/meminfo', 'r');
-        while ($line = fgets($fh)) {
-            $pieces = array();
-            if (preg_match('/^MemFree:\s+(\d+)\skB$/', $line, $pieces)) {
-                // KB to Bytes
-                $result = $pieces[1] * 1024;
-                break;
+        $top = shell_exec('free -m');
+        $output = preg_split('/[\s]/', $top);
+            for ($i=count($output)-1; $i>=0; $i--) {
+            if ($output[$i] == '') unset ($output[$i]);
             }
-        }
-        fclose($fh);
+        $output = array_values($output);
+        $ramFree = $output[16]/1000; // GB
+        $result = $ramFree;
     }
     // KB RAM Total
     return (int) $result;
@@ -164,6 +159,9 @@ function getRamFree()
 
 //define free ram variable
 $freeRam = getRamFree();
+
+//get Used RAM
+$usedRam = $totalRam - $freeRam;
 
 //uptime
 $uptime = shell_exec("cut -d. -f1 /proc/uptime");

--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -117,13 +117,13 @@ function getRamTotal()
             $result = $matches[1];
         }
     } else {
-        $top = shell_exec('free -m');
+        $top = shell_exec('free');
         $output = preg_split('/[\s]/', $top);
             for ($i=count($output)-1; $i>=0; $i--) {
             if ($output[$i] == '') unset ($output[$i]);
             }
         $output = array_values($output);
-        $ramTotal = $output[7]/1000; // GB
+        $ramTotal = $output[7];
         $result = $ramTotal;
     }
     // KB RAM Total
@@ -144,13 +144,13 @@ function getRamFree()
             $result = $matches[1] * 1024;
         }
     } else {
-        $top = shell_exec('free -m');
+        $top = shell_exec('free');
         $output = preg_split('/[\s]/', $top);
             for ($i=count($output)-1; $i>=0; $i--) {
             if ($output[$i] == '') unset ($output[$i]);
             }
         $output = array_values($output);
-        $ramFree = $output[16]/1000; // GB
+        $ramFree = $output[9];
         $result = $ramFree;
     }
     // KB RAM Total

--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -117,14 +117,17 @@ function getRamTotal()
             $result = $matches[1];
         }
     } else {
-        $top = shell_exec('free');
-        $output = preg_split('/[\s]/', $top);
-            for ($i=count($output)-1; $i>=0; $i--) {
-            if ($output[$i] == '') unset ($output[$i]);
+        $fh = fopen('/proc/meminfo', 'r');
+        while ($line = fgets($fh)) {
+            $pieces = array();
+            if (preg_match('/^MemTotal:\s+(\d+)\skB$/', $line, $pieces)) {
+                $result = $pieces[1];
+                // KB to Bytes
+                $result = $result * 1024;
+                break;
             }
-        $output = array_values($output);
-        $ramTotal = $output[7];
-        $result = $ramTotal;
+        }
+        fclose($fh);
     }
     // KB RAM Total
     return (int) $result;
@@ -144,14 +147,16 @@ function getRamFree()
             $result = $matches[1] * 1024;
         }
     } else {
-        $top = shell_exec('free');
-        $output = preg_split('/[\s]/', $top);
-            for ($i=count($output)-1; $i>=0; $i--) {
-            if ($output[$i] == '') unset ($output[$i]);
+        $fh = fopen('/proc/meminfo', 'r');
+        while ($line = fgets($fh)) {
+            $pieces = array();
+            if (preg_match('/^MemAvailable:\s+(\d+)\skB$/', $line, $pieces)) {
+                // KB to Bytes
+                $result = $pieces[1] * 1024;
+                break;
             }
-        $output = array_values($output);
-        $ramFree = $output[9];
-        $result = $ramFree;
+        }
+        fclose($fh);
     }
     // KB RAM Total
     return (int) $result;

--- a/assets/php/systembadges.php
+++ b/assets/php/systembadges.php
@@ -8,7 +8,7 @@
 </div>
 <div class="double-val-label">
   <span class="warning">RAM</span>
-  <span><?php echo round(($usedRam / $totalRam)*100); ?>%</span>
+  <span><?php echo round(($usedRam / $totalRam) * 100); ?>%</span>
 </div>
 <div class="double-val-label">
   <span class="primary">uptime</span>

--- a/assets/php/systembadges.php
+++ b/assets/php/systembadges.php
@@ -8,7 +8,7 @@
 </div>
 <div class="double-val-label">
   <span class="warning">RAM</span>
-  <span><?php echo round(($freeRam / $totalRam)*100); ?>%</span>
+  <span><?php echo round(($usedRam / $totalRam)*100); ?>%</span>
 </div>
 <div class="double-val-label">
   <span class="primary">uptime</span>


### PR DESCRIPTION
Some devices hold RAM in cache. The calculation was looking for Free RAM and not Available RAM so was reporting incorrectly. This will Fix #39 