### PR TITLE
Update default

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -8,15 +8,27 @@ server {
 
 	location / {
 		try_files $uri $uri/ /index.html /index.php?$args =404;
+		location ~ \.php$ {
+			fastcgi_split_path_info ^(.+\.php)(/.+)$;
+			# With php7-cgi alone:
+			fastcgi_pass 127.0.0.1:9000;
+			# With php7-fpm:
+			#fastcgi_pass unix:/var/run/php7-fpm.sock;
+			fastcgi_index index.php;
+			include /etc/nginx/fastcgi_params;
+		}
 	}
-	location ~ \.php$ {
-		fastcgi_split_path_info ^(.+\.php)(/.+)$;
-		# With php5-cgi alone:
-		fastcgi_pass 127.0.0.1:9000;
-		# With php5-fpm:
-		#fastcgi_pass unix:/var/run/php5-fpm.sock;
-		fastcgi_index index.php;
-		include /etc/nginx/fastcgi_params;
-
+	
+	location /monitorr/ {
+		root /config/www;
+		location ~ \.php$ {
+			fastcgi_split_path_info ^(.+\.php)(/.+)$;
+			# With php7-cgi alone:
+			fastcgi_pass 127.0.0.1:9000;
+			# With php7-fpm:
+			#fastcgi_pass unix:/var/run/php7-fpm.sock;
+			fastcgi_index index.php;
+			include /etc/nginx/fastcgi_params;
+		}
 	}
 }


### PR DESCRIPTION
Now listens to `/` and `/monitorr/`. Should now be able to run as subdomain and subdirectory.